### PR TITLE
Replace deprecated `ruff` with `ruff-lsp`

### DIFF
--- a/configs/lspconfig.lua
+++ b/configs/lspconfig.lua
@@ -5,8 +5,15 @@ local capabilities = config.capabilities
 
 local lspconfig = require("lspconfig")
 
-lspconfig.pyright.setup({
-  on_attach = on_attach,
-  capabilities = capabilities,
-  filetypes = {"python"},
-})
+local servers = {
+  "pyright",
+  "ruff_lsp",
+}
+
+for _, lsp in ipairs(servers) do
+  lspconfig[lsp].setup({
+    on_attach = on_attach,
+    capabilities = capabilities,
+    filetypes = {"python"},
+  })
+end

--- a/configs/null-ls.lua
+++ b/configs/null-ls.lua
@@ -10,7 +10,6 @@ local opts = {
       return { "--python-executable", virtual .. "/bin/python3" }
       end,
     }),
-    null_ls.builtins.diagnostics.ruff,
   },
   on_attach = function(client, bufnr)
     if client.supports_method("textDocument/formatting") then

--- a/plugins.lua
+++ b/plugins.lua
@@ -50,7 +50,7 @@ local plugins = {
         "black",
         "debugpy",
         "mypy",
-        "ruff",
+        "ruff-lsp",
         "pyright",
       },
     },


### PR DESCRIPTION
Support for `ruff` has been dropped by `none-ls` and this causes
an error any time a Python file is opened.
The recommended alternative by the `none-ls` team is to use
the `ruff-lsp`. This PR takes care of that.

Also, Closes #8
