### PR TITLE
Added nvim-nio plugin for use with nvim-dap

### DIFF
--- a/plugins.lua
+++ b/plugins.lua
@@ -1,5 +1,8 @@
 local plugins = {
   {
+    "nvim-neotest/nvim-nio",
+  },
+  {
     "rcarriga/nvim-dap-ui",
     dependencies = "mfussenegger/nvim-dap",
     config = function()
@@ -29,6 +32,7 @@ local plugins = {
     dependencies = {
       "mfussenegger/nvim-dap",
       "rcarriga/nvim-dap-ui",
+      "nvim-neotest/nvim-nio",
     },
     config = function(_, opts)
       local path = "~/.local/share/nvim/mason/packages/debugpy/venv/bin/python"


### PR DESCRIPTION
As is, attempting to use nvim-dap-ui with this configuration results in an error message suggesting this be dependency be added. Steps are in the [official docs](https://github.com/rcarriga/nvim-dap-ui?tab=readme-ov-file) as well.